### PR TITLE
Add support for Core Devices' updated pebble-tool

### DIFF
--- a/.github/workflows/buildAndCache.yml
+++ b/.github/workflows/buildAndCache.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Build pebble-tool
       run: nix build -L .#pebble-tool
 
+    - name: Build Core Devices pebble-tool
+      run: nix build -L .#coredevices.pebble-tool
+
     - name: Build pebble-qemu
       run: nix build -L .#pebble-qemu
 
@@ -37,3 +40,6 @@ jobs:
 
     - name: Build pebbleEnv
       run: nix shell -f default.nix pebbleEnv --command sh -c "echo OK"
+
+    - name: Build pebbleEnv with Core Devices pebble-tool
+      run: nix shell -f default.nix pebbleEnv --arg withCoreDevices true --command sh -c "echo OK"

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Development shells can be configured by specifying the following arguments to `p
 - `cloudPebble`: Whether to connect via a CloudPebble connection. Requires logging into Rebble via `pebble login`.
 - `packages`: Any extra tools to use during development.
 - `CFLAGS`: Extra flags to pass to the compiler during app builds.
+- `withCoreDevices`: Whether to use Core Devices' new pebble-tool, updated to work with Python 3. Defaults to `false`.
 
 ### App Store Builds
 

--- a/buildTools/pebbleEnv.nix
+++ b/buildTools/pebbleEnv.nix
@@ -1,5 +1,6 @@
 {
   mkShell,
+  coredevices,
   nodejs,
   pebble-qemu,
   pebble-tool,
@@ -13,6 +14,7 @@
   nativeBuildInputs ? [ ],
   packages ? [ ],
   CFLAGS ? "",
+  withCoreDevices ? false,
   ...
 }@attrs:
 
@@ -26,6 +28,8 @@ let
     "packages"
     "CFLAGS"
   ];
+
+  pebbleToolPackage = if withCoreDevices then coredevices.pebble-tool else pebble-tool;
 in
 mkShell (
   {
@@ -34,7 +38,7 @@ mkShell (
       [
         nodejs
         pebble-qemu
-        pebble-tool
+        pebbleToolPackage
         pebble-toolchain-bin
       ]
       ++ packages

--- a/derivations/coredevices/no-sdk-binaries.patch
+++ b/derivations/coredevices/no-sdk-binaries.patch
@@ -1,0 +1,25 @@
+diff --git a/pebble_tool/__init__.py b/pebble_tool/__init__.py
+index d0c99e0..95d0f4e 100644
+--- a/pebble_tool/__init__.py
++++ b/pebble_tool/__init__.py
+@@ -38,8 +38,6 @@ def run_tool(args=None):
+     version_string = "Pebble Tool v{}".format(__version__)
+     if sdk_version() is not None:
+         version_string += " (active SDK: v{})".format(sdk_version())
+-        # Add QEMU and others to PATH
+-        os.environ['PATH'] = "{}:{}".format(os.path.join(get_persist_dir(), "SDKs", sdk_version(), "toolchain", "bin"), os.environ['PATH'])
+     parser.add_argument("--version", action="version", version=version_string)
+     register_children(parser)
+     args = parser.parse_args(args)
+diff --git a/pebble_tool/sdk/__init__.py b/pebble_tool/sdk/__init__.py
+index d29ce5f..f3c74b1 100644
+--- a/pebble_tool/sdk/__init__.py
++++ b/pebble_tool/sdk/__init__.py
+@@ -35,5 +35,4 @@ def get_sdk_persist_dir(platform, for_sdk_version=None):
+     return dir
+ 
+ def add_tools_to_path():
+-    if sdk_version():
+-        os.environ['PATH'] = "{}:{}".format(os.path.join(get_persist_dir(), "SDKs", sdk_version(), "toolchain", "arm-none-eabi", "bin"), os.environ['PATH'])
+\ No newline at end of file
++    return

--- a/derivations/coredevices/pebble-tool.nix
+++ b/derivations/coredevices/pebble-tool.nix
@@ -55,6 +55,12 @@ python3Packages.buildPythonPackage {
     hash = "sha256-Ouhx7oam/uDdShZAPJjkMGm7SlCDSglWqDYzJ584aPY=";
   };
 
+  patches = [
+    # We have our own versions of the compiler toolchain and pebble-qemu, and we want to use those. SDK 4.4 ships
+    # precompiled versions of these, which won't work on NixOS.
+    ./no-sdk-binaries.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = [ nodejs ];

--- a/derivations/coredevices/pebble-tool.nix
+++ b/derivations/coredevices/pebble-tool.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  coredevices,
+  freetype,
+  nodejs,
+  python3Packages,
+  zlib,
+}:
+
+let
+  rpath = lib.makeLibraryPath [
+    freetype
+    zlib
+  ];
+
+  sourcemap = python3Packages.buildPythonPackage rec {
+    pname = "sourcemap";
+    version = "0.2.1";
+
+    src = fetchFromGitHub {
+      owner = "mattrobenolt";
+      repo = "python-sourcemap";
+      tag = version;
+      hash = "sha256-xVVBtwYPAsScYitINnKhj3XOgapXzQnXvmuF0B4Kuac=";
+    };
+  };
+
+  libpebble2 = python3Packages.buildPythonPackage {
+    pname = "libpebble2";
+    version = "0.0.28";
+    src = fetchFromGitHub {
+      owner = "pebble-dev";
+      repo = "libpebble2";
+      rev = "575fe2cfae39e1a1c61937d4e90628a3d5790a4d";
+      hash = "sha256-bQNeJoiQhg/twMcYpgvBOG/mutm3Fuf9iwF0y5UgWs0=";
+    };
+
+    propagatedBuildInputs = with python3Packages; [
+      pyserial
+      six
+      websocket_client
+    ];
+  };
+in
+python3Packages.buildPythonPackage {
+  pname = "pebble-tool";
+  version = "5.0.2";
+
+  src = fetchFromGitHub {
+    owner = "coredevices";
+    repo = "pebble-tool";
+    rev = "d99857c7a30695d0fd710a25e2bb4689c57b58ef";
+    hash = "sha256-Ouhx7oam/uDdShZAPJjkMGm7SlCDSglWqDYzJ584aPY=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ nodejs ];
+
+  propagatedBuildInputs = with python3Packages; [
+    coredevices.pypkjs
+    colorama
+    httplib2
+    libpebble2
+    oauth2client
+    packaging
+    progressbar2
+    pyasn1
+    pyasn1-modules
+    pypng
+    pyqrcode
+    pyserial
+    requests
+    rsa
+    six
+    sourcemap
+    websocket-client
+    wheel
+
+    freetype
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/pebble \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --prefix LD_LIBRARY_PATH : ${rpath} \
+      --prefix DYLD_LIBRARY_PATH : ${rpath}
+  '';
+
+  meta = with lib; {
+    homepage = "https://developer.rebble.io/developer.pebble.com/index.html";
+    description = "Tool for interacting with the Pebble SDK";
+    license = licenses.mit;
+    mainProgram = "pebble";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/derivations/coredevices/pypkjs.nix
+++ b/derivations/coredevices/pypkjs.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  python3Packages,
+  fetchFromGitHub,
+  fetchPypi,
+  autoPatchelfHook,
+  makeWrapper,
+  zlib,
+}:
+
+let
+  stpyv8 = python3Packages.buildPythonPackage rec {
+    pname = "stpyv8";
+    version = "13.1.201.22";
+
+    src =
+      let
+        pyShortVersion = "cp" + builtins.replaceStrings [ "." ] [ "" ] python3Packages.python.pythonVersion;
+      in
+      fetchPypi {
+        inherit pname version;
+        format = "wheel";
+        dist = pyShortVersion;
+        python = pyShortVersion;
+        abi = pyShortVersion;
+        platform =
+          ({
+            x86_64-linux = "manylinux_2_31_x86_64";
+            x86_64-darwin = "macosx_13_0_x86_64";
+            aarch64-darwin = "macosx_14_0_arm64";
+          }).${stdenv.hostPlatform.system};
+        hash =
+          ({
+            x86_64-linux = "sha256-wkqkIVxk231n/GxCwNdzHKvPMAWWv5yCaudPQm/jt3E=";
+            x86_64-darwin = "sha256-/CuVa/ryNTHEkIRe232A/JmP6K7hx88TNzF9rgEWkwc=";
+            aarch64-darwin = "sha256-bcQLZWzqf+VB9r262DtrTtUeXq2YW1TBOTGacxJTpV4=";
+          }).${stdenv.hostPlatform.system};
+      };
+
+    pyproject = false;
+
+    nativeBuildInputs = [
+      python3Packages.pypaInstallHook
+      python3Packages.wheelUnpackHook
+    ] ++ (lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook);
+
+    buildInputs = [ zlib ];
+  };
+
+  pygeoip = python3Packages.buildPythonPackage rec {
+    pname = "pygeoip";
+    version = "0.3.2";
+
+    src = fetchFromGitHub {
+      owner = "appliedsec";
+      repo = "pygeoip";
+      tag = "v${version}";
+      hash = "sha256-D058c3o+2rTMQJpgwvFKd5Qwt2j7u4+GFpQHjO7lOVQ=";
+    };
+  };
+in
+python3Packages.buildPythonPackage {
+  pname = "pypkjs";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "coredevices";
+    repo = "pypkjs";
+    rev = "9561f7ba3be73e2546b1cfdf6dcfbb416a7f64ca";
+    hash = "sha256-/ZRwKXzQ5tHrViyfrEsI/sOQepCND7/Fr6AEHMUhuws=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = with python3Packages; [
+    gevent
+    gevent-websocket
+    greenlet
+    netaddr
+    peewee
+    pygeoip
+    pypng
+    stpyv8
+    dateutil
+    requests
+    sh
+    six
+    websocket_client
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/pypkjs \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/pebble/pypkjs";
+    description = "Python implementation of PebbleKit JS";
+    license = licenses.mit;
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -43,12 +43,13 @@
           inherit pkgs nixpkgs system;
           pebble-tool = packages.pebble-tool;
           python-libs = pkgs.callPackage ./derivations/pebble-tool/python-libs.nix { };
-        };
 
+        };
         packages = {
           inherit (pkgs)
             arm-embedded-toolchain
             boost153
+            coredevices
             pdc-sequencer
             pdc_tool
             pebble-qemu
@@ -89,6 +90,11 @@
         pebble-toolchain-bin = final.callPackage ./derivations/pebble-toolchain-bin.nix { };
         pypkjs = final.pebble-tool.passthru.pythonLibs.pypkjs;
         pyv8 = final.callPackage ./derivations/pyv8 { };
+
+        coredevices = {
+          pypkjs = final.callPackage ./derivations/coredevices/pypkjs.nix { };
+          pebble-tool = final.callPackage ./derivations/coredevices/pebble-tool.nix { };
+        };
       };
 
       templates = rec {


### PR DESCRIPTION
Core Devices have been working on an [updated pebble-tool](https://github.com/coredevices/pebble-tool), updated to work with Python 3 instead of Python 2. This PR packages it, and adds an option to use it in `pebbleEnv` dev shells.